### PR TITLE
[feat] 가격 트래킹과 연동할 카카오 알림 모듈 구현

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ mcp[cli]
 # langgraph>=0.3.21
 fastapi_mcp
 asyncio
-FlashrankRerank
 
 # pip install -r requirements.txt
 # 실행 cmd simplify용

--- a/runs/test/kakao/alert_api.py
+++ b/runs/test/kakao/alert_api.py
@@ -1,0 +1,25 @@
+# alert_api.py
+from kakao_msg import send_friend_template
+
+WELCOME_TMPL_ID  = "121168"
+SCHEDULE_TMPL_ID = "121173"
+PRICE_TMPL_ID    = "121171"
+
+# 이메일 → UUID 매핑 (하드코딩)
+EMAIL_UUID = {
+    "user1@example.com": "R39Of0l5SX9OYlNlXWpdbldnS3pIfUtzR3UC"
+}
+
+def _uuid(email: str) -> str:
+    if email not in EMAIL_UUID:
+        raise ValueError("Unknown email")
+    return EMAIL_UUID[email]
+
+def send_welcome(email: str, auth_code_if_needed: str | None = None):
+    return send_friend_template(_uuid(email), WELCOME_TMPL_ID, {}, auth_code_if_needed)
+
+def send_schedule(email: str, arg_dict: dict, auth_code_if_needed: str | None = None):
+    return send_friend_template(_uuid(email), SCHEDULE_TMPL_ID, arg_dict, auth_code_if_needed)
+
+def send_price_alert(email: str, arg_dict: dict, auth_code_if_needed: str | None = None):
+    return send_friend_template(_uuid(email), PRICE_TMPL_ID, arg_dict, auth_code_if_needed)

--- a/runs/test/kakao/alert_api.py
+++ b/runs/test/kakao/alert_api.py
@@ -1,25 +1,14 @@
-# alert_api.py
 from kakao_msg import send_friend_template
 
 WELCOME_TMPL_ID  = "121168"
 SCHEDULE_TMPL_ID = "121173"
 PRICE_TMPL_ID    = "121171"
 
-# 이메일 → UUID 매핑 (하드코딩)
-EMAIL_UUID = {
-    "user1@example.com": "R39Of0l5SX9OYlNlXWpdbldnS3pIfUtzR3UC"
-}
+def send_welcome(email: str):
+    return send_friend_template(email, WELCOME_TMPL_ID, {})
 
-def _uuid(email: str) -> str:
-    if email not in EMAIL_UUID:
-        raise ValueError("Unknown email")
-    return EMAIL_UUID[email]
+def send_schedule(email: str, arg_dict: dict):
+    return send_friend_template(email, SCHEDULE_TMPL_ID, arg_dict)
 
-def send_welcome(email: str, auth_code_if_needed: str | None = None):
-    return send_friend_template(_uuid(email), WELCOME_TMPL_ID, {}, auth_code_if_needed)
-
-def send_schedule(email: str, arg_dict: dict, auth_code_if_needed: str | None = None):
-    return send_friend_template(_uuid(email), SCHEDULE_TMPL_ID, arg_dict, auth_code_if_needed)
-
-def send_price_alert(email: str, arg_dict: dict, auth_code_if_needed: str | None = None):
-    return send_friend_template(_uuid(email), PRICE_TMPL_ID, arg_dict, auth_code_if_needed)
+def send_price_alert(email: str, arg_dict: dict):
+    return send_friend_template(email, PRICE_TMPL_ID, arg_dict)

--- a/runs/test/kakao/global_token.py
+++ b/runs/test/kakao/global_token.py
@@ -1,0 +1,82 @@
+# global_token.py
+import time, requests
+
+KAUTH = "https://kauth.kakao.com/oauth/token"
+CLIENT_ID     = "b4a89fae7185745b6e0ff46dc4c60a7b"
+CLIENT_SECRET = "HvXeqHCmZjgOBl2015RvxGDgcbbsV0cb"
+REDIRECT_URI  = "http://localhost:4000/dummy"   # 실제 등록된 URI
+
+# 메모리 전역 토큰 (앱 시작 시 try_load() 로 초기화)
+TOKEN = {
+    "access_token":  None,
+    "refresh_token": None,
+    "expires_at":    0
+}
+
+# ---- 파일 또는 DB 에 영구 저장하고 싶으면 아래 두 함수 구현만 교체 ----
+import json, os
+_STORE = "kakao_global_token.json"
+
+def try_load():
+    if os.path.exists(_STORE):
+        TOKEN.update(json.load(open(_STORE, encoding="utf-8")))
+
+def save():
+    json.dump(TOKEN, open(_STORE, "w", encoding="utf-8"))
+
+# ------------------------------------------------------------------------
+
+def _need_refresh() -> bool:
+    """토큰이 없거나 30초 안에 만료되면 True"""
+    return not TOKEN["access_token"] or TOKEN["expires_at"] < time.time() + 30
+
+def _refresh_with_refresh_token():
+    """refresh_token으로 access_token 재발급"""
+    data = {
+        "grant_type":    "refresh_token",
+        "client_id":     CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "refresh_token": TOKEN["refresh_token"]
+    }
+    r = requests.post(KAUTH, data=data, timeout=10)
+    r.raise_for_status()
+    j = r.json()
+    TOKEN["access_token"] = j["access_token"]
+    TOKEN["expires_at"]   = time.time() + j["expires_in"]
+    if j.get("refresh_token"):
+        TOKEN["refresh_token"] = j["refresh_token"]
+    save()
+
+def _issue_with_authorization_code(auth_code: str):
+    """최초/만료 시 authorization_code 로 새 토큰 발급"""
+    data = {
+        "grant_type":    "authorization_code",
+        "client_id":     CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+        "redirect_uri":  REDIRECT_URI,
+        "code":          auth_code
+    }
+    r = requests.post(KAUTH, data=data, timeout=10)
+    r.raise_for_status()
+    j = r.json()
+    TOKEN.update({
+        "access_token":  j["access_token"],
+        "refresh_token": j["refresh_token"],
+        "expires_at":    time.time() + j["expires_in"]
+    })
+    save()
+
+def ensure_access_token(auth_code_if_needed: str | None = None) -> str:
+    """
+    1) access_token 이 유효하면 그대로 반환
+    2) 만료됐으면 refresh_token 재발급
+    3) refresh_token 도 없으면 auth_code 로 신규 발급
+    """
+    if _need_refresh():
+        if TOKEN["refresh_token"]:
+            _refresh_with_refresh_token()
+        elif auth_code_if_needed:
+            _issue_with_authorization_code(auth_code_if_needed)
+        else:
+            raise RuntimeError("No valid token. Provide Kakao auth_code.")
+    return TOKEN["access_token"]

--- a/runs/test/kakao/global_token.py
+++ b/runs/test/kakao/global_token.py
@@ -1,37 +1,31 @@
-# global_token.py
-import time, requests
+import time, json, os, requests
+from dotenv import load_dotenv
+from user_data import TOKEN
+
+load_dotenv()
 
 KAUTH = "https://kauth.kakao.com/oauth/token"
-CLIENT_ID     = "b4a89fae7185745b6e0ff46dc4c60a7b"
-CLIENT_SECRET = "HvXeqHCmZjgOBl2015RvxGDgcbbsV0cb"
-REDIRECT_URI  = "http://localhost:4000/dummy"   # 실제 등록된 URI
+CLIENT_ID     = os.getenv("CLIENT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
-# 메모리 전역 토큰 (앱 시작 시 try_load() 로 초기화)
-TOKEN = {
-    "access_token":  None,
-    "refresh_token": None,
-    "expires_at":    0
-}
-
-# ---- 파일 또는 DB 에 영구 저장하고 싶으면 아래 두 함수 구현만 교체 ----
-import json, os
 _STORE = "kakao_global_token.json"
 
+# ──────────────────────────────────────────────
 def try_load():
+    """앱 시작 시 디스크에 저장된 토큰 불러오기"""
     if os.path.exists(_STORE):
         TOKEN.update(json.load(open(_STORE, encoding="utf-8")))
 
 def save():
-    json.dump(TOKEN, open(_STORE, "w", encoding="utf-8"))
+    """토큰 정보 영구 저장"""
+    json.dump(TOKEN, open(_STORE, "w", encoding="utf-8"), ensure_ascii=False)
 
-# ------------------------------------------------------------------------
-
+# ──────────────────────────────────────────────
 def _need_refresh() -> bool:
-    """토큰이 없거나 30초 안에 만료되면 True"""
-    return not TOKEN["access_token"] or TOKEN["expires_at"] < time.time() + 30
+    """access_token이 없거나 곧 만료(True)"""
+    return (not TOKEN["access_token"]) or TOKEN["expires_at"] < time.time() + 30
 
 def _refresh_with_refresh_token():
-    """refresh_token으로 access_token 재발급"""
     data = {
         "grant_type":    "refresh_token",
         "client_id":     CLIENT_ID,
@@ -43,40 +37,18 @@ def _refresh_with_refresh_token():
     j = r.json()
     TOKEN["access_token"] = j["access_token"]
     TOKEN["expires_at"]   = time.time() + j["expires_in"]
-    if j.get("refresh_token"):
+    if j.get("refresh_token"):                       # 새 refresh_token이 오면 교체
         TOKEN["refresh_token"] = j["refresh_token"]
     save()
 
-def _issue_with_authorization_code(auth_code: str):
-    """최초/만료 시 authorization_code 로 새 토큰 발급"""
-    data = {
-        "grant_type":    "authorization_code",
-        "client_id":     CLIENT_ID,
-        "client_secret": CLIENT_SECRET,
-        "redirect_uri":  REDIRECT_URI,
-        "code":          auth_code
-    }
-    r = requests.post(KAUTH, data=data, timeout=10)
-    r.raise_for_status()
-    j = r.json()
-    TOKEN.update({
-        "access_token":  j["access_token"],
-        "refresh_token": j["refresh_token"],
-        "expires_at":    time.time() + j["expires_in"]
-    })
-    save()
-
-def ensure_access_token(auth_code_if_needed: str | None = None) -> str:
+def ensure_access_token() -> str:
     """
-    1) access_token 이 유효하면 그대로 반환
-    2) 만료됐으면 refresh_token 재발급
-    3) refresh_token 도 없으면 auth_code 로 신규 발급
+    항상 최신 access_token 반환.
+    refresh_token이 있으면 자동 재발급.
     """
+    try_load()
     if _need_refresh():
-        if TOKEN["refresh_token"]:
-            _refresh_with_refresh_token()
-        elif auth_code_if_needed:
-            _issue_with_authorization_code(auth_code_if_needed)
-        else:
-            raise RuntimeError("No valid token. Provide Kakao auth_code.")
+        if not TOKEN["refresh_token"]:
+            raise RuntimeError("refresh_token not set")
+        _refresh_with_refresh_token()
     return TOKEN["access_token"]

--- a/runs/test/kakao/kakao_alert.py
+++ b/runs/test/kakao/kakao_alert.py
@@ -1,30 +1,82 @@
-# test_alert.py
-import alert_api as api, time, sys, json, global_token as gt
+import sys
+import json
+import alert_api as api
+import global_token as gt
+from dotenv import load_dotenv
+import os
 
-gt.try_load()                    # 디스크에 저장돼 있던 토큰 로드
+load_dotenv()
 
-email  = sys.argv[1]
-which  = sys.argv[2]
+# 저장된 토큰을 메모리로 불러오기
+gt.try_load()
 
-# 최초 실행이라 토큰이 없으면 auth_code 인자를 넣어주세요.
-auth_code = None   # 예: "KakaoRedirect에서받은code"  (1회만 필요)
+# .env에 설정한 이메일/UUID 정보
+USER_EMAIL = os.getenv("USER_EMAIL")
+if not USER_EMAIL:
+    print("ERROR: 환경 변수 USER_EMAIL이 설정되어 있지 않습니다.")
+    sys.exit(1)
 
-SCHEDULE_ARGS = {
-    "ORIGIN":"서울","DEST":"제주","AIRLINE":"KAL","DEPARTDATE":"2025.06.01",
-    "TARGET_PRICE":"120000","CURRENT_PRICE":"118500",
-    "CHANGE_RATE":"-1.25","BOOK_URL":"https://bookie-chatbot.vercel.app/flights?src=sel&dst=cju"
-}
-PRICE_ARGS = {
-    "ORIGIN":"서울","DEST":"제주","AIRLINE":"KAL","DEPARTDATE":"2025.06.01",
-    "TARGET_PRICE":"120000",
-    "BOOK_URL":"https://bookie-chatbot.vercel.app/flights?src=sel&dst=cju"
-}
 
-if which == "welcome":
-    print(api.send_welcome(email, auth_code))
-elif which == "schedule":
-    print(api.send_schedule(email, SCHEDULE_ARGS, auth_code))
-elif which == "price":
-    print(api.send_price_alert(email, PRICE_ARGS, auth_code))
-else:
-    print("unknown command")
+
+async def main():
+    SCHEDULE_ARGS = {
+        "ORIGIN": "서울",
+        "DEST": "제주",
+        "AIRLINE": "KAL",
+        "DEPARTDATE": "2025.06.01",
+        "TARGET_PRICE": "120000",
+        "CURRENT_PRICE": "118500",
+        "CHANGE_RATE": "-1.25",
+        "BOOK_URL": "https://chatbot-bookie.pages.dev"
+    }
+    PRICE_ARGS = {
+        "ORIGIN": "서울",
+        "DEST": "제주",
+        "AIRLINE": "KAL",
+        "DEPARTDATE": "2025.06.01",
+        "TARGET_PRICE": "120000",
+        "BOOK_URL": "https://chatbot-bookie.pages.dev"
+    }
+
+    while True:
+        print("\n=== 카카오 알림 테스트 메뉴 ===")
+        print("1) 웰컴 메시지 보내기")
+        print("2) 스케줄링 알림 보내기")
+        print("3) 가격 임계치 알림 보내기")
+        print("Q) 종료")
+        choice = input("메뉴 번호를 입력하세요 (1/2/3 또는 Q): ").strip().lower()
+
+        if choice == "q":
+            print("프로그램을 종료합니다.")
+            return
+
+        try:
+            if choice == "1":
+                response = api.send_welcome(USER_EMAIL)
+                print("\n--- 웰컴 메시지 결과 ---")
+                if response.get("successful_receiver_uuids"):
+                    print("웰컴 메시지가 성공적으로 전송되었습니다.")
+            elif choice == "2":
+                response = api.send_schedule(USER_EMAIL, SCHEDULE_ARGS)
+                print("\n--- 스케줄링 알림 결과 ---")
+                if response.get("successful_receiver_uuids"):
+                    print("스케줄링 알림이 성공적으로 전송되었습니다.")
+            elif choice == "3":
+                response = api.send_price_alert(USER_EMAIL, PRICE_ARGS)
+                print("\n--- 가격 임계치 알림 결과 ---")
+                if response.get("successful_receiver_uuids"):
+                    print("가격 임계치 알림이 성공적으로 전송되었습니다.")
+            else:
+                print("잘못된 입력입니다. 1, 2, 3 중 하나 또는 Q를 입력해 주세요.")
+        except Exception as e:
+            print(f"오류 발생: {e}")
+
+
+if __name__ == "__main__":
+    try:
+        import asyncio
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        print("\n프로그램이 중단되었습니다.")
+    except Exception as e:
+        print(f"예상치 못한 오류 발생: {e}")

--- a/runs/test/kakao/kakao_alert.py
+++ b/runs/test/kakao/kakao_alert.py
@@ -1,0 +1,30 @@
+# test_alert.py
+import alert_api as api, time, sys, json, global_token as gt
+
+gt.try_load()                    # 디스크에 저장돼 있던 토큰 로드
+
+email  = sys.argv[1]
+which  = sys.argv[2]
+
+# 최초 실행이라 토큰이 없으면 auth_code 인자를 넣어주세요.
+auth_code = None   # 예: "KakaoRedirect에서받은code"  (1회만 필요)
+
+SCHEDULE_ARGS = {
+    "ORIGIN":"서울","DEST":"제주","AIRLINE":"KAL","DEPARTDATE":"2025.06.01",
+    "TARGET_PRICE":"120000","CURRENT_PRICE":"118500",
+    "CHANGE_RATE":"-1.25","BOOK_URL":"https://bookie-chatbot.vercel.app/flights?src=sel&dst=cju"
+}
+PRICE_ARGS = {
+    "ORIGIN":"서울","DEST":"제주","AIRLINE":"KAL","DEPARTDATE":"2025.06.01",
+    "TARGET_PRICE":"120000",
+    "BOOK_URL":"https://bookie-chatbot.vercel.app/flights?src=sel&dst=cju"
+}
+
+if which == "welcome":
+    print(api.send_welcome(email, auth_code))
+elif which == "schedule":
+    print(api.send_schedule(email, SCHEDULE_ARGS, auth_code))
+elif which == "price":
+    print(api.send_price_alert(email, PRICE_ARGS, auth_code))
+else:
+    print("unknown command")

--- a/runs/test/kakao/kakao_global_token.json
+++ b/runs/test/kakao/kakao_global_token.json
@@ -1,0 +1,1 @@
+{"access_token": "XpEwjUX9XAq7MLKTJnFTvaY4GZJocIl0AAAAAQoXAVAAAAGXKAv63MYNwJ_muSR4", "refresh_token": "VyO9Kqp2E4TmObObmaf1zYh7isAeNGKUAAAAAgoNFZsAAAGXKAXa_8YNwJ_muSR4", "expires_at": 1748745160.206188}

--- a/runs/test/kakao/kakao_msg.py
+++ b/runs/test/kakao/kakao_msg.py
@@ -1,0 +1,23 @@
+# kakao_msg.py
+import json, requests
+from global_token import ensure_access_token
+
+KAPI = "https://kapi.kakao.com"
+
+def send_friend_template(uuid: str, template_id: str, args: dict,
+                         auth_code_if_needed: str | None = None) -> dict:
+    access = ensure_access_token(auth_code_if_needed)
+    headers = {
+        "Authorization": f"Bearer {access}",
+        "Content-Type":  "application/x-www-form-urlencoded;charset=utf-8"
+    }
+    data = {
+        "receiver_uuids": json.dumps([uuid], ensure_ascii=False),
+        "template_id":    template_id
+    }
+    if args:
+        data["template_args"] = json.dumps(args, ensure_ascii=False)
+
+    r = requests.post(f"{KAPI}/v1/api/talk/friends/message/send",
+                      headers=headers, data=data, timeout=10)
+    return r.json()

--- a/runs/test/kakao/kakao_msg.py
+++ b/runs/test/kakao/kakao_msg.py
@@ -1,18 +1,21 @@
-# kakao_msg.py
 import json, requests
 from global_token import ensure_access_token
+from user_data     import EMAIL_UUID
 
 KAPI = "https://kapi.kakao.com"
 
-def send_friend_template(uuid: str, template_id: str, args: dict,
-                         auth_code_if_needed: str | None = None) -> dict:
-    access = ensure_access_token(auth_code_if_needed)
+def send_friend_template(email: str, template_id: str, args: dict) -> dict:
+    if email not in EMAIL_UUID:
+        raise ValueError(f"unknown email={email}")
+    uuid = EMAIL_UUID[email]
+
+    access = ensure_access_token()
     headers = {
         "Authorization": f"Bearer {access}",
         "Content-Type":  "application/x-www-form-urlencoded;charset=utf-8"
     }
     data = {
-        "receiver_uuids": json.dumps([uuid], ensure_ascii=False),
+        "receiver_uuids": json.dumps([uuid]),
         "template_id":    template_id
     }
     if args:
@@ -20,4 +23,5 @@ def send_friend_template(uuid: str, template_id: str, args: dict,
 
     r = requests.post(f"{KAPI}/v1/api/talk/friends/message/send",
                       headers=headers, data=data, timeout=10)
+    r.raise_for_status()
     return r.json()

--- a/runs/test/kakao/user_data.py
+++ b/runs/test/kakao/user_data.py
@@ -1,0 +1,16 @@
+import os, time
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# 이메일 → 친구 UUID 매핑
+EMAIL_UUID = {
+    os.getenv("USER_EMAIL"): os.getenv("USER_UUID")
+}
+
+# 전역 토큰: access_token 없음, refresh_token만 미리 지정
+TOKEN = {
+    "access_token":  None,
+   "refresh_token": os.getenv("REFRESH_TOKEN"),
+    "expires_at":    0                # 만료 시각 0 → 즉시 갱신 시도
+}


### PR DESCRIPTION
# 추가 파일 (runs/test/kakao)
- alert_api.py에 템플릿별 API 함수(send_welcome/send_schedule/send_price_alert) 추가되어 있음 
   -> celery 트래킹 결과에 따라서 alert_api.py에 구현된 2가지 함수중 알맞은거 호출하면 될듯
- global_token.py에서 리프레시 토큰 로드/갱신 로직 구현
- kakao_msg.py에서 액세스 토큰 확인 후 커스텀 템플릿 메시지 전송
- user_data.py에서 USER_EMAIL/USER_UUID 매핑 
- kakao_alert.py는 CLI 테스트용 메뉴(1: 웰컴, 2: 스케줄, 3: 가격 알림)에 해당함 (celery에서 호출할 때 참고용으로 추가함)

<img width="660" alt="image" src="https://github.com/user-attachments/assets/32e8458f-0921-443b-a339-5dbe22499211" />

# 카카오 관련 .env 설정 필수 항목
USER_EMAIL, USER_UUID, CLIENT_ID, CLIENT_SECRET, REFRESH_TOKEN
(개발할 땐, 가족껄로 테스트했어서  팀원 중에 앱에 친구 등록되면 그  USER_UUID 받아서 전송 테스트하면 될 것 같음) 

# 테스트 실행 명령어
- 우선 cd runs/test/kakao 
- python kakao_alert.py
- cmd에 1/2/3

# 토큰 처리 로직 
global_token.py의 try_load()로 시작 시 kakao_global_token.json에서 기존 토큰 로드

ensure_access_token() 호출 시 _need_refresh()로 만료 상태 확인

만료 임박하면 _refresh_with_refresh_token()에서 카카오 OAuth 엔드포인트에 POST 요청

응답으로 받은 새 access_token, expires_in 값을 TOKEN 딕셔너리에 반영

새로운 refresh_token이 제공되면 기존 값 교체 후 save()로 디스크에 저장

save() 함수는 kakao_global_token.json에 JSON형태로 access_token/refresh_token/expires_at 기록

API 요청 전 항상 ensure_access_token()을 호출하여 유효한 토큰 확보

expires_at은 현재 시간 기준으로 expires_in 초 이후로 설정되어 자동 갱신 트리거

Celery 워커가 재시작되어도 try_load()로 토큰 재사용 가능

토큰 에러 발생 시 예외를 발생시켜 호출자(Celery 태스크)가 재시도 로직 처리 가능

# 기타
## 토큰 저장 파일 
실행 시 kakao_global_token.json 파일이 자동 생성/업데이트
만약 권한 만료 등으로 Refresh Token을 재발급받아야 할 때는, .env의 REFRESH_TOKEN 값을 수정해야 (2달이 기한이라고해서 굳이 안건드려도 될듯)
## 템플릿 ID 관리
현재 사용 중인 템플릿 ID
웰컴: 121168 / 스케줄링: 121173 /가격 알림: 121171

